### PR TITLE
Update Maintenance.php

### DIFF
--- a/admin/modules/Maintenance/Maintenance.php
+++ b/admin/modules/Maintenance/Maintenance.php
@@ -121,7 +121,9 @@ class Maintenance extends CodonModule {
         foreach ($all_pilots as $pilot) {
             
             $pireps = PIREPData::getReportsByAcceptStatus($pilot->pilotid, PIREP_ACCEPTED);
-            $total = count($pireps);
+            if(is_array ($pireps) || $pireps instanceof Countable) {
+		$total = count($pireps);
+	    }
             unset($pireps);
 
             $code = PilotData::getPilotCode($pilot->code, $pilot->pilotid);


### PR DESCRIPTION
Bring up to date with 5.5.2.72 base

Maintenance.php - count() parameter must be array or object
Warning: count(): Parameter must be an array or an object that implements Countable in ...\admin\modules\Maintenance\Maintenance.php on line 124

Add to make array or object
if (is_array($pireps) || $pireps instanceof Countable) {
.....
}